### PR TITLE
env: npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1833,9 +1833,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
```console
$ npm audit
# npm audit report

ajv  <6.14.0
Severity: moderate
ajv has ReDoS when using `$data` option - https://github.com/advisories/GHSA-2g4f-4pwh-qvx6
fix available via `npm audit fix`
node_modules/ajv

1 moderate severity vulnerability

To address all issues, run:
  npm audit fix
exited 1
$ npm audit fix

up to date, audited 237 packages in 1s

64 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
$ npm audit
found 0 vulnerabilities
```